### PR TITLE
Add missing footer to html templates

### DIFF
--- a/files/etc/mailman/templates/en/archidxfoot.html
+++ b/files/etc/mailman/templates/en/archidxfoot.html
@@ -32,7 +32,7 @@
       </div>
   </div>
   <div class="container mt-4">
-      <p class="text-muted credit text-center">&copy; 2019 The CentOS Project | <a href="/legal/">Legal</a> | <a href="/legal/privacy/">Privacy</a></p>
+      <p class="text-muted credit text-center">&copy; 2019 The CentOS Project | <a href="https://www.centos.org/legal/">Legal</a> | <a href="https://www.centos.org/legal/privacy/">Privacy</a></p>
   </div>
   </footer>
   <!-- Optional JavaScript -->

--- a/files/etc/mailman/templates/en/archtoc.html
+++ b/files/etc/mailman/templates/en/archtoc.html
@@ -114,7 +114,7 @@
         </div>
     </div>
     <div class="container mt-4">
-        <p class="text-muted credit text-center">&copy; 2019 The CentOS Project | <a href="/legal/">Legal</a> | <a href="/legal/privacy/">Privacy</a></p>
+        <p class="text-muted credit text-center">&copy; 2019 The CentOS Project | <a href="https://www.centos.org/legal/">Legal</a> | <a href="https://www.centos.org/legal/privacy/">Privacy</a></p>
     </div>
     </footer>
 

--- a/files/etc/mailman/templates/en/archtocnombox.html
+++ b/files/etc/mailman/templates/en/archtocnombox.html
@@ -112,7 +112,7 @@
         </div>
     </div>
     <div class="container mt-4">
-        <p class="text-muted credit text-center">&copy; 2019 The CentOS Project | <a href="/legal/">Legal</a> | <a href="/legal/privacy/">Privacy</a></p>
+        <p class="text-muted credit text-center">&copy; 2019 The CentOS Project | <a href="https://www.centos.org/legal/">Legal</a> | <a href="https://www.centos.org/legal/privacy/">Privacy</a></p>
     </div>
     </footer>
     <!-- Optional JavaScript -->

--- a/files/etc/mailman/templates/en/article.html
+++ b/files/etc/mailman/templates/en/article.html
@@ -145,7 +145,7 @@
         </div>
     </div>
     <div class="container mt-4">
-        <p class="text-muted credit text-center">&copy; 2019 The CentOS Project | <a href="/legal/">Legal</a> | <a href="/legal/privacy/">Privacy</a></p>
+        <p class="text-muted credit text-center">&copy; 2019 The CentOS Project | <a href="https://www.centos.org/legal/">Legal</a> | <a href="https://www.centos.org/legal/privacy/">Privacy</a></p>
     </div>
     </footer>
     <!-- Optional JavaScript -->

--- a/files/etc/mailman/templates/en/emptyarchive.html
+++ b/files/etc/mailman/templates/en/emptyarchive.html
@@ -109,7 +109,7 @@
         </div>
     </div>
     <div class="container mt-4">
-        <p class="text-muted credit text-center">&copy; 2019 The CentOS Project | <a href="/legal/">Legal</a> | <a href="/legal/privacy/">Privacy</a></p>
+        <p class="text-muted credit text-center">&copy; 2019 The CentOS Project | <a href="https://www.centos.org/legal/">Legal</a> | <a href="https://www.centos.org/legal/privacy/">Privacy</a></p>
     </div>
     </footer>
     <!-- Optional JavaScript -->

--- a/files/etc/mailman/templates/en/listinfo.html
+++ b/files/etc/mailman/templates/en/listinfo.html
@@ -163,3 +163,31 @@
 	<MM-Form-End>        
 
 <MM-Mailman-Footer>
+
+  </div>
+  </main>
+
+<footer class="footer pt-4 bg-light sticky-bottom">
+<div class="container">
+    <div class="row">
+        <div class="col">
+            <h2>Sponsor</h2>
+            <p>This site would not be possible without the support of <a href="http://steadfast.net/">steadfast</a>. We would like to thank <a href="http://steadfast.net/">steadfast</a> for being a CentOS sponsor.</p>
+            <p>If you value our work, please consider <a href="https://www.centos.org/sponsors/">becoming a sponsor!</a></p>
+        </div>
+        <div class="col col-lg-4 mt-4">
+            <a href="http://steadfast.net/" rel="nofollow"><img class="d-block w-100 img-rounded" src="https://www.centos.org/images/sponsors/steadfast.png"></a>
+        </div>
+    </div>
+</div>
+<div class="container mt-4">
+    <p class="text-muted credit text-center">&copy; 2019 The CentOS Project | <a href="https://www.centos.org/legal/">Legal</a> | <a href="https://www.centos.org/legal/privacy/">Privacy</a></p>
+</div>
+</footer>
+<!-- Optional JavaScript -->
+<!-- jQuery first, then Popper.js, then Bootstrap JS -->
+<script src="https://code.jquery.com/jquery-3.3.1.slim.min.js" integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo" crossorigin="anonymous"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js" integrity="sha384-UO2eT0CpHqdSJQ6hJty5KVphtPhzWj9WO1clHTMGa3JDZwrnQq4sF86dIHNDz0W1" crossorigin="anonymous"></script>
+<script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js" integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM" crossorigin="anonymous"></script>
+</body>
+</html>

--- a/files/etc/mailman/templates/en/options.html
+++ b/files/etc/mailman/templates/en/options.html
@@ -346,3 +346,31 @@
 <MM-Form-End>
 
 <MM-Mailman-Footer>
+
+</div>
+</main>
+
+<footer class="footer pt-4 bg-light sticky-bottom">
+<div class="container">
+    <div class="row">
+        <div class="col">
+            <h2>Sponsor</h2>
+            <p>This site would not be possible without the support of <a href="http://steadfast.net/">steadfast</a>. We would like to thank <a href="http://steadfast.net/">steadfast</a> for being a CentOS sponsor.</p>
+            <p>If you value our work, please consider <a href="https://www.centos.org/sponsors/">becoming a sponsor!</a></p>
+        </div>
+        <div class="col col-lg-4 mt-4">
+            <a href="http://steadfast.net/" rel="nofollow"><img class="d-block w-100 img-rounded" src="https://www.centos.org/images/sponsors/steadfast.png"></a>
+        </div>
+    </div>
+</div>
+<div class="container mt-4">
+    <p class="text-muted credit text-center">&copy; 2019 The CentOS Project | <a href="https://www.centos.org/legal/">Legal</a> | <a href="https://www.centos.org/legal/privacy/">Privacy</a></p>
+</div>
+</footer>
+<!-- Optional JavaScript -->
+<!-- jQuery first, then Popper.js, then Bootstrap JS -->
+<script src="https://code.jquery.com/jquery-3.3.1.slim.min.js" integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo" crossorigin="anonymous"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js" integrity="sha384-UO2eT0CpHqdSJQ6hJty5KVphtPhzWj9WO1clHTMGa3JDZwrnQq4sF86dIHNDz0W1" crossorigin="anonymous"></script>
+<script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js" integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM" crossorigin="anonymous"></script>
+</body>
+</html>

--- a/files/etc/mailman/templates/en/private.html
+++ b/files/etc/mailman/templates/en/private.html
@@ -150,7 +150,7 @@
       </div>
   </div>
   <div class="container mt-4">
-      <p class="text-muted credit text-center">&copy; 2019 The CentOS Project | <a href="/legal/">Legal</a> | <a href="/legal/privacy/">Privacy</a></p>
+      <p class="text-muted credit text-center">&copy; 2019 The CentOS Project | <a href="https://www.centos.org/legal/">Legal</a> | <a href="https://www.centos.org/legal/privacy/">Privacy</a></p>
   </div>
   </footer>
   <!-- Optional JavaScript -->

--- a/files/etc/mailman/templates/en/roster.html
+++ b/files/etc/mailman/templates/en/roster.html
@@ -109,3 +109,31 @@
     </table>
 
 <MM-Mailman-Footer>
+
+  </div>
+  </main>
+
+<footer class="footer pt-4 bg-light sticky-bottom">
+<div class="container">
+    <div class="row">
+        <div class="col">
+            <h2>Sponsor</h2>
+            <p>This site would not be possible without the support of <a href="http://steadfast.net/">steadfast</a>. We would like to thank <a href="http://steadfast.net/">steadfast</a> for being a CentOS sponsor.</p>
+            <p>If you value our work, please consider <a href="https://www.centos.org/sponsors/">becoming a sponsor!</a></p>
+        </div>
+        <div class="col col-lg-4 mt-4">
+            <a href="http://steadfast.net/" rel="nofollow"><img class="d-block w-100 img-rounded" src="https://www.centos.org/images/sponsors/steadfast.png"></a>
+        </div>
+    </div>
+</div>
+<div class="container mt-4">
+    <p class="text-muted credit text-center">&copy; 2019 The CentOS Project | <a href="https://www.centos.org/legal/">Legal</a> | <a href="https://www.centos.org/legal/privacy/">Privacy</a></p>
+</div>
+</footer>
+<!-- Optional JavaScript -->
+<!-- jQuery first, then Popper.js, then Bootstrap JS -->
+<script src="https://code.jquery.com/jquery-3.3.1.slim.min.js" integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo" crossorigin="anonymous"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js" integrity="sha384-UO2eT0CpHqdSJQ6hJty5KVphtPhzWj9WO1clHTMGa3JDZwrnQq4sF86dIHNDz0W1" crossorigin="anonymous"></script>
+<script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js" integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM" crossorigin="anonymous"></script>
+</body>
+</html>

--- a/files/etc/mailman/templates/en/subscribe.html
+++ b/files/etc/mailman/templates/en/subscribe.html
@@ -83,3 +83,31 @@
     <h1><MM-List-Name> Subscription results</h1>
     <MM-Results>
     <MM-Mailman-Footer>
+
+  </div>
+  </main>
+
+<footer class="footer pt-4 bg-light sticky-bottom">
+<div class="container">
+    <div class="row">
+        <div class="col">
+            <h2>Sponsor</h2>
+            <p>This site would not be possible without the support of <a href="http://steadfast.net/">steadfast</a>. We would like to thank <a href="http://steadfast.net/">steadfast</a> for being a CentOS sponsor.</p>
+            <p>If you value our work, please consider <a href="https://www.centos.org/sponsors/">becoming a sponsor!</a></p>
+        </div>
+        <div class="col col-lg-4 mt-4">
+            <a href="http://steadfast.net/" rel="nofollow"><img class="d-block w-100 img-rounded" src="https://www.centos.org/images/sponsors/steadfast.png"></a>
+        </div>
+    </div>
+</div>
+<div class="container mt-4">
+    <p class="text-muted credit text-center">&copy; 2019 The CentOS Project | <a href="https://www.centos.org/legal/">Legal</a> | <a href="https://www.centos.org/legal/privacy/">Privacy</a></p>
+</div>
+</footer>
+<!-- Optional JavaScript -->
+<!-- jQuery first, then Popper.js, then Bootstrap JS -->
+<script src="https://code.jquery.com/jquery-3.3.1.slim.min.js" integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo" crossorigin="anonymous"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js" integrity="sha384-UO2eT0CpHqdSJQ6hJty5KVphtPhzWj9WO1clHTMGa3JDZwrnQq4sF86dIHNDz0W1" crossorigin="anonymous"></script>
+<script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js" integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM" crossorigin="anonymous"></script>
+</body>
+</html>


### PR DESCRIPTION
- This commit also changes links to CentOS legal and CentOS
  legal/privacy pages to use the entire url pointing to
  https://www.centos.org/.