### PR TITLE
Fix copyright line out of footer

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -125,7 +125,7 @@ mailman_html_tpl_bodyclose: |
             <p>If you value our work, please consider <a href="https://www.centos.org/sponsors/">becoming a sponsor!</a></p>
         </div>
         <div class="col col-lg-4 mt-4">
-            <a href="http://steadfast.net/" rel="nofollow"><img class="d-block w-100 img-rounded" src="https://www.centos.org/images/sponsors/steadfast.png"></a>
+            <a href="http://steadfast.net/" rel="nofollow"><img class="d-block h-100 img-rounded" src="https://www.centos.org/images/sponsors/steadfast.png"></a>
         </div>
     </div>
   </div>

--- a/files/etc/mailman/templates/en/archidxfoot.html
+++ b/files/etc/mailman/templates/en/archidxfoot.html
@@ -27,7 +27,7 @@
               <p>If you value our work, please consider <a href="https://www.centos.org/sponsors/">becoming a sponsor!</a></p>
           </div>
           <div class="col col-lg-4 mt-4">
-              <a href="http://steadfast.net/" rel="nofollow"><img class="d-block w-100 img-rounded" src="https://www.centos.org/images/sponsors/steadfast.png"></a>
+              <a href="http://steadfast.net/" rel="nofollow"><img class="d-block h-100 img-rounded" src="https://www.centos.org/images/sponsors/steadfast.png"></a>
           </div>
       </div>
   </div>

--- a/files/etc/mailman/templates/en/archtoc.html
+++ b/files/etc/mailman/templates/en/archtoc.html
@@ -109,7 +109,7 @@
                 <p>If you value our work, please consider <a href="https://www.centos.org/sponsors/">becoming a sponsor!</a></p>
             </div>
             <div class="col col-lg-4 mt-4">
-                <a href="http://steadfast.net/" rel="nofollow"><img class="d-block w-100 img-rounded" src="https://www.centos.org/images/sponsors/steadfast.png"></a>
+                <a href="http://steadfast.net/" rel="nofollow"><img class="d-block h-100 img-rounded" src="https://www.centos.org/images/sponsors/steadfast.png"></a>
             </div>
         </div>
     </div>

--- a/files/etc/mailman/templates/en/archtocnombox.html
+++ b/files/etc/mailman/templates/en/archtocnombox.html
@@ -107,7 +107,7 @@
                 <p>If you value our work, please consider <a href="https://www.centos.org/sponsors/">becoming a sponsor!</a></p>
             </div>
             <div class="col col-lg-4 mt-4">
-                <a href="http://steadfast.net/" rel="nofollow"><img class="d-block w-100 img-rounded" src="https://www.centos.org/images/sponsors/steadfast.png"></a>
+                <a href="http://steadfast.net/" rel="nofollow"><img class="d-block h-100 img-rounded" src="https://www.centos.org/images/sponsors/steadfast.png"></a>
             </div>
         </div>
     </div>

--- a/files/etc/mailman/templates/en/article.html
+++ b/files/etc/mailman/templates/en/article.html
@@ -139,7 +139,7 @@
                 <p>If you value our work, please consider <a href="https://www.centos.org/sponsors/">becoming a sponsor!</a></p>
             </div>
             <div class="col col-lg-4 mt-4">
-                <a href="http://steadfast.net/" rel="nofollow"><img class="d-block w-100 img-rounded" src="https://www.centos.org/images/sponsors/steadfast.png"></a>
+                <a href="http://steadfast.net/" rel="nofollow"><img class="d-block h-100 img-rounded" src="https://www.centos.org/images/sponsors/steadfast.png"></a>
             </div>
         </div>
     </div>

--- a/files/etc/mailman/templates/en/emptyarchive.html
+++ b/files/etc/mailman/templates/en/emptyarchive.html
@@ -104,7 +104,7 @@
                 <p>If you value our work, please consider <a href="https://www.centos.org/sponsors/">becoming a sponsor!</a></p>
             </div>
             <div class="col col-lg-4 mt-4">
-                <a href="http://steadfast.net/" rel="nofollow"><img class="d-block w-100 img-rounded" src="https://www.centos.org/images/sponsors/steadfast.png"></a>
+                <a href="http://steadfast.net/" rel="nofollow"><img class="d-block h-100 img-rounded" src="https://www.centos.org/images/sponsors/steadfast.png"></a>
             </div>
         </div>
     </div>

--- a/files/etc/mailman/templates/en/listinfo.html
+++ b/files/etc/mailman/templates/en/listinfo.html
@@ -212,7 +212,7 @@
             <p>If you value our work, please consider <a href="https://www.centos.org/sponsors/">becoming a sponsor!</a></p>
         </div>
         <div class="col col-lg-4 mt-4">
-            <a href="http://steadfast.net/" rel="nofollow"><img class="d-block w-100 img-rounded" src="https://www.centos.org/images/sponsors/steadfast.png"></a>
+            <a href="http://steadfast.net/" rel="nofollow"><img class="d-block h-100 img-rounded" src="https://www.centos.org/images/sponsors/steadfast.png"></a>
         </div>
     </div>
 </div>

--- a/files/etc/mailman/templates/en/options.html
+++ b/files/etc/mailman/templates/en/options.html
@@ -359,7 +359,7 @@
             <p>If you value our work, please consider <a href="https://www.centos.org/sponsors/">becoming a sponsor!</a></p>
         </div>
         <div class="col col-lg-4 mt-4">
-            <a href="http://steadfast.net/" rel="nofollow"><img class="d-block w-100 img-rounded" src="https://www.centos.org/images/sponsors/steadfast.png"></a>
+            <a href="http://steadfast.net/" rel="nofollow"><img class="d-block h-100 img-rounded" src="https://www.centos.org/images/sponsors/steadfast.png"></a>
         </div>
     </div>
 </div>

--- a/files/etc/mailman/templates/en/private.html
+++ b/files/etc/mailman/templates/en/private.html
@@ -142,7 +142,7 @@
               <p>If you value our work, please consider <a href="https://www.centos.org/sponsors/">becoming a sponsor!</a></p>
           </div>
           <div class="col col-lg-4 mt-4">
-              <a href="http://steadfast.net/" rel="nofollow"><img class="d-block w-100 img-rounded" src="https://www.centos.org/images/sponsors/steadfast.png"></a>
+              <a href="http://steadfast.net/" rel="nofollow"><img class="d-block h-100 img-rounded" src="https://www.centos.org/images/sponsors/steadfast.png"></a>
           </div>
       </div>
   </div>

--- a/files/etc/mailman/templates/en/roster.html
+++ b/files/etc/mailman/templates/en/roster.html
@@ -122,7 +122,7 @@
             <p>If you value our work, please consider <a href="https://www.centos.org/sponsors/">becoming a sponsor!</a></p>
         </div>
         <div class="col col-lg-4 mt-4">
-            <a href="http://steadfast.net/" rel="nofollow"><img class="d-block w-100 img-rounded" src="https://www.centos.org/images/sponsors/steadfast.png"></a>
+            <a href="http://steadfast.net/" rel="nofollow"><img class="d-block h-100 img-rounded" src="https://www.centos.org/images/sponsors/steadfast.png"></a>
         </div>
     </div>
 </div>

--- a/files/etc/mailman/templates/en/subscribe.html
+++ b/files/etc/mailman/templates/en/subscribe.html
@@ -96,7 +96,7 @@
             <p>If you value our work, please consider <a href="https://www.centos.org/sponsors/">becoming a sponsor!</a></p>
         </div>
         <div class="col col-lg-4 mt-4">
-            <a href="http://steadfast.net/" rel="nofollow"><img class="d-block w-100 img-rounded" src="https://www.centos.org/images/sponsors/steadfast.png"></a>
+            <a href="http://steadfast.net/" rel="nofollow"><img class="d-block h-100 img-rounded" src="https://www.centos.org/images/sponsors/steadfast.png"></a>
         </div>
     </div>
 </div>


### PR DESCRIPTION
- Previously, the sponsor image was using the column width for automatic
  expansion. This made the copyright line to look out of the footer
  area (because the image exapands in height and pushes it down). 

  ![image](https://user-images.githubusercontent.com/5214519/70830141-51bc8800-1dce-11ea-8b4d-3942b1446f18.png)

  This update changes the sponsor image expansion orientation from width to
  height so the copyright line look inside the footer area.

  ![image](https://user-images.githubusercontent.com/5214519/70830251-90ead900-1dce-11ea-8423-abeb48e35f8c.png)