### PR TITLE
Fix sponsor footer height

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -41,6 +41,7 @@ mailman_html_tpl_head: |
   <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css">
   <!-- CentOS customization -->
   <link href="/centos-design/css/centos.css" rel="stylesheet">
+  <link href="/centos-design/css/centos-sponsors.css" rel="stylesheet">
   <!-- Favicon -->
   <link href="/centos-design/images/favicon.ico" rel="icon" type="image/png" />
   <!-- Fonts -->

--- a/files/etc/mailman/templates/en/admlogin.html
+++ b/files/etc/mailman/templates/en/admlogin.html
@@ -8,6 +8,7 @@
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">
     <!-- CentOS customization -->
     <link href="/centos-design/css/centos.css" rel="stylesheet">
+    <link href="/centos-design/css/centos-sponsors.css" rel="stylesheet">
     <!-- Favicon -->
     <link href="/centos-design/images/favicon.ico" rel="icon" type="image/ico" />
     <!-- Fonts -->

--- a/files/etc/mailman/templates/en/archidxhead.html
+++ b/files/etc/mailman/templates/en/archidxhead.html
@@ -10,6 +10,7 @@
 
     <!-- CentOS customization -->
     <link href="/centos-design/css/centos.css" rel="stylesheet">
+    <link href="/centos-design/css/centos-sponsors.css" rel="stylesheet">
 
     <!-- Favicon -->
     <link href="/centos-design/images/favicon.ico" rel="icon" type="image/ico" />

--- a/files/etc/mailman/templates/en/archtoc.html
+++ b/files/etc/mailman/templates/en/archtoc.html
@@ -10,6 +10,7 @@
 
     <!-- CentOS customization -->
     <link href="/centos-design/css/centos.css" rel="stylesheet">
+    <link href="/centos-design/css/centos-sponsors.css" rel="stylesheet">
 
     <!-- Favicon -->
     <link href="/centos-design/images/favicon.ico" rel="icon" type="image/ico" />

--- a/files/etc/mailman/templates/en/archtocnombox.html
+++ b/files/etc/mailman/templates/en/archtocnombox.html
@@ -10,6 +10,7 @@
 
     <!-- CentOS customization -->
     <link href="/centos-design/css/centos.css" rel="stylesheet">
+    <link href="/centos-design/css/centos-sponsors.css" rel="stylesheet">
 
     <!-- Favicon -->
     <link href="/centos-design/images/favicon.ico" rel="icon" type="image/ico" />

--- a/files/etc/mailman/templates/en/article.html
+++ b/files/etc/mailman/templates/en/article.html
@@ -10,6 +10,7 @@
 
     <!-- CentOS customization -->
     <link href="/centos-design/css/centos.css" rel="stylesheet">
+    <link href="/centos-design/css/centos-sponsors.css" rel="stylesheet">
 
     <!-- Favicon -->
     <link href="/centos-design/images/favicon.ico" rel="icon" type="image/ico" />

--- a/files/etc/mailman/templates/en/emptyarchive.html
+++ b/files/etc/mailman/templates/en/emptyarchive.html
@@ -10,6 +10,7 @@
 
     <!-- CentOS customization -->
     <link href="/centos-design/css/centos.css" rel="stylesheet">
+    <link href="/centos-design/css/centos-sponsors.css" rel="stylesheet">
 
     <!-- Favicon -->
     <link href="/centos-design/images/favicon.ico" rel="icon" type="image/ico" />

--- a/files/etc/mailman/templates/en/listinfo.html
+++ b/files/etc/mailman/templates/en/listinfo.html
@@ -9,6 +9,7 @@
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css">
     <!-- CentOS customization -->
     <link href="/centos-design/css/centos.css" rel="stylesheet">
+    <link href="/centos-design/css/centos-sponsors.css" rel="stylesheet">
     <!-- Favicon -->
     <link href="/centos-design/images/favicon.ico" rel="icon" type="image/ico" />
     <!-- Fonts -->

--- a/files/etc/mailman/templates/en/options.html
+++ b/files/etc/mailman/templates/en/options.html
@@ -9,6 +9,7 @@
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css">
     <!-- CentOS customization -->
     <link href="/centos-design/css/centos.css" rel="stylesheet">
+    <link href="/centos-design/css/centos-sponsors.css" rel="stylesheet">
     <!-- Favicon -->
     <link href="/centos-design/images/favicon.ico" rel="icon" type="image/ico" />
     <!-- Fonts -->

--- a/files/etc/mailman/templates/en/private.html
+++ b/files/etc/mailman/templates/en/private.html
@@ -9,6 +9,7 @@
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css">
     <!-- CentOS customization -->
     <link href="/centos-design/css/centos.css" rel="stylesheet">
+    <link href="/centos-design/css/centos-sponsors.css" rel="stylesheet">
     <!-- Favicon -->
     <link href="/centos-design/images/favicon.ico" rel="icon" type="image/ico" />
     <!-- Fonts -->

--- a/files/etc/mailman/templates/en/roster.html
+++ b/files/etc/mailman/templates/en/roster.html
@@ -10,6 +10,7 @@
 
     <!-- CentOS customization -->
     <link href="/centos-design/css/centos.css" rel="stylesheet">
+    <link href="/centos-design/css/centos-sponsors.css" rel="stylesheet">
 
     <!-- Favicon -->
     <link href="/centos-design/images/favicon.ico" rel="icon" type="image/ico" />

--- a/files/etc/mailman/templates/en/subscribe.html
+++ b/files/etc/mailman/templates/en/subscribe.html
@@ -9,6 +9,7 @@
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css">
     <!-- CentOS customization -->
     <link href="/centos-design/css/centos.css" rel="stylesheet">
+    <link href="/centos-design/css/centos-sponsors.css" rel="stylesheet">
     <!-- Favicon -->
     <link href="/centos-design/images/favicon.ico" rel="icon" type="image/ico" />
     <!-- Fonts -->


### PR DESCRIPTION
- Previously, the footer was using the default height that is smaller
  than sponsor presentation needs. As consequence the footer
  presentation looked cut. This update adds centos-sponsors.css which
  resets the footer height considering sponsor presentation.

Before:
![image](https://user-images.githubusercontent.com/5214519/70850065-102aec00-1e65-11ea-8bb9-39cb4a68d195.png)

After:
![image](https://user-images.githubusercontent.com/5214519/70850087-305aab00-1e65-11ea-952a-0dc688981474.png)

